### PR TITLE
Make script imports dynamic.

### DIFF
--- a/http_request_translator/base.py
+++ b/http_request_translator/base.py
@@ -16,6 +16,8 @@ class AbstractScript(object):
 
     """Abstract representation of a script."""
 
+    __language__ = ''
+
     code_begin = ''
     code_header = ''
     code_proxy = ''

--- a/http_request_translator/plugin_manager.py
+++ b/http_request_translator/plugin_manager.py
@@ -1,27 +1,24 @@
 from __future__ import print_function
 
-from .script import BashScript, PHPScript, PythonScript, RubyScript
+from .base import AbstractScript
 
 
-def hardcoded_script_import(script_name):
-    """Manually find the class of the script.
+def get_script_class(script_name):
+    """Returns the class of the script.
 
-    :param str script_name: Name of the script from which to import the function.
+    :param str script_name: language name of the script class which we want to import
 
     :raises ValueError: When the script is not supported.
 
     :return: The class of the `script_name` script.
     :rtype: :class:`AbstractScript`
     """
-    if script_name == 'bash':
-        return BashScript
-    elif script_name == 'php':
-        return PHPScript
-    elif script_name == 'python':
-        return PythonScript
-    elif script_name == 'ruby':
-        return RubyScript
-    raise ValueError("The '%s' language is not supported yet." % script_name)
+    script_name = script_name.strip().lower()
+
+    for script_class in AbstractScript.__subclasses__():
+        if script_name == script_class.__language__:
+            return script_class
+    raise ValueError("The {} language is not supported.".format(script_name))
 
 
 def generate_script(script, headers, details, search_string=None):
@@ -35,5 +32,5 @@ def generate_script(script, headers, details, search_string=None):
     :return: A combined string of generated code
     :rtype: `str`
     """
-    class_script = hardcoded_script_import(script.strip().lower())
+    class_script = get_script_class(script.strip().lower())
     return class_script(headers=headers, details=details, search=search_string).generate_script()

--- a/http_request_translator/script.py
+++ b/http_request_translator/script.py
@@ -9,10 +9,14 @@ from .templates import bash_template, php_template, python_template, ruby_templa
 
 
 class BashScript(AbstractScript):
+
     """Extended `AbstractScript` class for Bash script code generation.
     Fills code variables for the request from `bash_template`.
     Overrides `_generate_request` method to generate bash specific code.
     """
+
+    __language__ = 'bash'
+
     code_begin = bash_template.code_begin
     code_header = bash_template.code_header
     code_proxy = bash_template.code_proxy
@@ -31,10 +35,14 @@ class BashScript(AbstractScript):
 
 
 class PHPScript(AbstractScript):
+
     """Extended `AbstractScript` class for PHP script code generation.
     Fills code variables for the request from `php_template`.
     Overrides `_generate_begin` method to generate php specific code.
     """
+
+    __language__ = 'php'
+
     code_begin = php_template.code_begin
     code_header = php_template.code_header
     code_proxy = php_template.code_proxy
@@ -47,10 +55,14 @@ class PHPScript(AbstractScript):
 
 
 class PythonScript(AbstractScript):
+
     """Extended `AbstractScript` class for Python script code generation.
     Fills code variables for the request from `python_template`.
     Overrides `_generate_begin` method to generate python specific code.
     """
+
+    __language__ = 'python'
+
     code_begin = python_template.code_begin
     code_proxy = python_template.code_proxy
     code_post = python_template.code_post
@@ -63,10 +75,14 @@ class PythonScript(AbstractScript):
 
 
 class RubyScript(AbstractScript):
+
     """Extended `AbstractScript` class for Ruby script code generation.
     Fills code variables for the request from `ruby_template`.
     Overrides `_generate_begin` method to generate Ruby specific code.
     """
+
+    __language__ = 'ruby'
+
     code_begin = ruby_template.code_begin
     code_header = ruby_template.code_header
     code_proxy = ruby_template.code_proxy


### PR DESCRIPTION
I changed the If-else logic written in the `hardcoded_script_import()` method in `plugin_manager.py`.
I created a script_mapping dict which contains a mapping of script-name to its corresponding class.
Along with that, the script_name parameter is now cleaned(using strip()) and lowered down in this method itself to reduce coupledness.
