### PR TITLE
fix bug: valid language mismatch error

### DIFF
--- a/http_request_translator/plugin_manager.py
+++ b/http_request_translator/plugin_manager.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 from .base import AbstractScript
+from .script import BashScript, PHPScript, PythonScript, RubyScript
 
 
 def get_script_class(script_name):


### PR DESCRIPTION
Since the script classes were not in scope, the `get_script_class` method was always throwing ValueError.
Now I've imported all the scripts in scope.
